### PR TITLE
Include iptables in Podman installation instructions

### DIFF
--- a/2023/podman-dockge-20231126/index.md
+++ b/2023/podman-dockge-20231126/index.md
@@ -65,7 +65,7 @@ Boot into the new Alpine LXC and run the following commands.
 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 apk update
 apk upgrade
-apk add fuse-overlayfs podman-docker podman-compose
+apk add fuse-overlayfs podman-docker podman-compose iptables
 # Ensure Podman uses fuse-overlayfs.
 sed -i -e 's:.*mount_program *=.*:mount_program = "/usr/bin/fuse-overlayfs":' /etc/containers/storage.conf
 # Always start Podman on boot.


### PR DESCRIPTION
Added iptables to the list of packages installed for Podman.

When I tried to bring up dockge the first time I got an error that said `Error: netavark: No such file or directory (os error 2)`

Found this issue: https://github.com/containers/podman/issues/16958

Installed `iptables` and then all was well.

(Thanks for this helpful guide)